### PR TITLE
Search the list in hash bucket HashTable.aa

### DIFF
--- a/src/test/java/com/cliffc/aa/HashTable.aa
+++ b/src/test/java/com/cliffc/aa/HashTable.aa
@@ -5,11 +5,20 @@
 HashTable = {@{     // No args, returns a hash table struct
   tab = [7];        // The table
 
+  // Search the linked list for a key
+  // takes a linked list (list) and a key (key) 
+  // returns the value or a nil to indicate not found
+  search = { list key ->
+    list ? (
+      list.key.eq(key) ? list.val : search(list.next,  key)
+    )
+  };
+
   // Takes a key, which has a field 'hash' which has a no-arg function
   // and a field 'eq' which takes an arg.
   get = { key ->
     entry = tab[key.hash() % #tab];
-    entry && key.eq(entry.key) ? entry.val;
+    search(entry, key)
   };
   
   // Takes a key, which has a field 'hash' which has a no-arg function


### PR DESCRIPTION
In java I would often program defensively 
```
  search = { list key ->
    list ? (
      list.key && list.key.eq(key) ? list.val : search(list.next,  key)
    )
  };
```

but in AA we some types are not nullable so the check for list.key may be harmful as it fails to assert the non Null property of list.key
```
  search = { list key ->
    list ? (
      list.key.eq(key) ? list.val : search(list.next,  key)
    )
  };
```