### PR TITLE
AssertionError when a function has duplicate parameter names

### DIFF
--- a/src/main/java/com/cliffc/aa/Parse.java
+++ b/src/main/java/com/cliffc/aa/Parse.java
@@ -870,6 +870,8 @@ public class Parse implements Comparable<Parse> {
 
     // Parse arguments
     while( true ) {
+      skipWS();
+      Parse badp = errMsg();   // Capture location in case of parameter error
       String tok = token();
       if( tok == null ) { _x=oldx; break; } // not a "[id]* ->"
       if( Util.eq((tok=tok.intern()),"->") ) break; // End of argument list
@@ -889,7 +891,8 @@ public class Parse implements Comparable<Parse> {
           skipNonWS();         // Skip possible type sig, looking for next arg
         }
       }
-      formals = formals.add_fld(tok,Access.Final,t,ARG_IDX+bads._len); // Accumulate args
+      if( formals.fld_find(tok) != null ) err_ctrl3("Duplicate parameter name '" + tok + "'", badp);
+      else formals = formals.add_fld(tok,Access.Final,t,ARG_IDX+bads._len); // Accumulate args
       bads.add(bad);
     }
     // If this is a no-arg function, we may have parsed 1 or 2 tokens as-if

--- a/src/test/java/com/cliffc/aa/TestParse.java
+++ b/src/test/java/com/cliffc/aa/TestParse.java
@@ -259,6 +259,7 @@ public class TestParse {
     // This test merges 2 TypeFunPtrs in a Phi, and then fails to resolve.
     testerr("(math.rand(1) ? {_+_} : {_*_})(2,3)","Unable to resolve call",30); // either 2+3 or 2*3, or {5,6} which is INT8.
     test("f = g = {-> 3}; f() == g();", TypeInt.TRUE);
+    testerr("add = {x:int x:int -> x + x}", "Duplicate parameter name 'x'", 13);
   }
 
   @Test public void testParse03() {


### PR DESCRIPTION
For example,

```
run("f = {x:int x:int -> x + x}");
```

yields

```
java.lang.AssertionError
	at com.cliffc.aa.type.TypeStruct.add_fld(TypeStruct.java:1129)
	at com.cliffc.aa.Parse.func(Parse.java:894)
	…
```

Replacing this with a proper parsing error.
