### PR TITLE
Avoid ArrayIndexOutOfBoundsException in MemJoinNode#value

### DIFF
--- a/src/main/java/com/cliffc/aa/node/MemJoinNode.java
+++ b/src/main/java/com/cliffc/aa/node/MemJoinNode.java
@@ -147,11 +147,13 @@ public class MemJoinNode extends Node {
     Ary<BitsAlias> escs = msp()._escs;
     TypeObj[] pubs = new TypeObj[Env.DEFMEM._defs._len];
     for( int alias=1, i; alias<Env.DEFMEM._defs._len; alias++ ) {
+      i=0;                                 // In the base memory
       if( escs.at(0).test_recur(alias) ) { // In some RHS set
-        for( i=1; i<_defs._len; i++ )
-          if( escs.at(i).test_recur(alias) )
+        for( int j=1; j<_defs._len; j++ )
+          if( escs.at(j).test_recur(alias) )
+            i=j;
             break;
-      } else i=0;                     // In the base memory
+      }
       if( alias == 1 || Env.DEFMEM.in(alias) != null ) // Check never-made aliases
         pubs[alias] = mems[i].at(alias); // Merge alias
     }


### PR DESCRIPTION
I ran into a lot of errors like this:

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3
        at com.cliffc.aa.node.MemJoinNode.value(MemJoinNode.java)
        at com.cliffc.aa.node.Node.do_flow(Node.java)
        …
```

(Side note: I'm still trying to understand why the line numbers are missing from these stack traces, because the LineNumberTables are definitely present in the class files.  I'm guessing it's a limitation the testing tool that I'm using.)

It turns out there is a potential problem in MemJoinNode#value.

```
      if( escs.at(0).test_recur(alias) ) { // In some RHS set
        for( i=1; i<_defs._len; i++ )
          if( escs.at(i).test_recur(alias) )
            break;
      } else i=0;                     // In the base memory
      if( alias == 1 || Env.DEFMEM.in(alias) != null ) // Check never-made aliases
        pubs[alias] = mems[i].at(alias); // Merge alias
                      ^^^^^^^
```

If we take the first branch, `i` can be incremented just out of bounds, _i.e._ `i == _defs.len` at the end of the loop, in which case `mems[i]` will throw an exception.

In this case -- if we make it through the loop without a hit -- I'm guessing `i` should be set to zero.  Correct me if I'm wrong here.
